### PR TITLE
Fix: Update Proposal Routes

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -26,7 +26,8 @@ class ProposalsController < ApplicationController
   end
 
   def show
-    case (proposal = Proposal.find_by(proposal_id: params.fetch(:proposal_id, nil)))
+    proposal_id = params.fetch(:proposal_id)
+    case (proposal = Proposal.find_by(proposal_id: proposal_id))
     when nil
       render json: error_response(:proposal_not_found),
              status: :not_found
@@ -36,7 +37,8 @@ class ProposalsController < ApplicationController
   end
 
   def like
-    unless (proposal = Proposal.find_by(id: params.fetch(:id)))
+    proposal_id = params.fetch(:proposal_id)
+    unless (proposal = Proposal.find_by(proposal_id: proposal_id))
       return render json: error_response(:proposal_not_found),
                     status: :not_found
     end
@@ -47,12 +49,15 @@ class ProposalsController < ApplicationController
     when :database_error, :already_liked
       render json: error_response(proposal_or_error || result)
     when :ok
-      render json: result_response(proposal_or_error)
+      render json: result_response(
+        user_proposal_view(current_user, proposal_or_error)
+      )
     end
   end
 
   def unlike
-    unless (proposal = Proposal.find_by(id: params.fetch(:id)))
+    proposal_id = params.fetch(:proposal_id)
+    unless (proposal = Proposal.find_by(proposal_id: proposal_id))
       return render json: error_response(:proposal_not_found),
                     status: :not_found
     end
@@ -63,7 +68,9 @@ class ProposalsController < ApplicationController
     when :database_error, :not_liked
       render json: error_response(proposal_or_error || result)
     when :ok
-      render json: result_response(proposal_or_error)
+      render json: result_response(
+        user_proposal_view(current_user, proposal_or_error)
+      )
     end
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -17,6 +17,11 @@ class Proposal < ApplicationRecord
             presence: true,
             uniqueness: true
 
+  def as_json(options = {})
+    serializable_hash(options.merge(except: %i[id]))
+      .deep_transform_keys! { |key| key.camelize(:lower) }
+  end
+
   def user_like(user)
     ProposalLike.find_by(proposal_id: id, user_id: user.id)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,10 +37,10 @@ Rails.application.routes.draw do
   get '/proposals(/:proposal_id)',
       to: 'proposals#show',
       as: 'proposal'
-  post '/proposals/(:id)/likes',
+  post '/proposals/(:proposal_id)/likes',
        to: 'proposals#like',
        as: 'proposal_likes'
-  delete '/proposals/(:id)/likes',
+  delete '/proposals/(:proposal_id)/likes',
          to: 'proposals#unlike'
 
   get '/comments/(:id)/threads',

--- a/test/controllers/proposals_controller_test.rb
+++ b/test/controllers/proposals_controller_test.rb
@@ -54,6 +54,8 @@ class ProposalsControllerTest < ActionDispatch::IntegrationTest
                     'should work'
     assert_match 'id', @response.body,
                  'response should contain id'
+    assert_match 'liked', @response.body,
+                 'response should contain liked'
 
     get proposal_path('NON_EXISTENT_ID'),
         headers: auth_headers
@@ -66,13 +68,15 @@ class ProposalsControllerTest < ActionDispatch::IntegrationTest
     _user, auth_headers, _key = create_auth_user
     proposal = create(:proposal)
 
-    post proposal_likes_path(proposal.id),
+    post proposal_likes_path(proposal.proposal_id),
          headers: auth_headers
 
     assert_response :success,
                     'should work'
     assert_match 'id', @response.body,
                  'response should contain id'
+    assert_match 'liked', @response.body,
+                 'response should contain liked'
 
     post proposal_likes_path('NON_EXISTENT_ID'),
          headers: auth_headers
@@ -80,7 +84,7 @@ class ProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found,
                     'should fail to find proposal'
 
-    post proposal_likes_path(proposal.id),
+    post proposal_likes_path(proposal.proposal_id),
          headers: auth_headers
 
     assert_response :success,
@@ -92,14 +96,17 @@ class ProposalsControllerTest < ActionDispatch::IntegrationTest
   test 'unliking a proposal should work' do
     user, auth_headers, _key = create_auth_user
     like = create(:proposal_like, user: user)
+    proposal = like.proposal
 
-    delete proposal_likes_path(like.proposal_id),
+    delete proposal_likes_path(proposal.proposal_id),
            headers: auth_headers
 
     assert_response :success,
                     'should work'
     assert_match 'id', @response.body,
                  'response should contain id'
+    assert_match 'liked', @response.body,
+                 'response should contain liked'
 
     delete proposal_likes_path('NON_EXISTENT_ID'),
            headers: auth_headers
@@ -107,7 +114,7 @@ class ProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found,
                     'should fail to find proposal'
 
-    delete proposal_likes_path(like.proposal_id),
+    delete proposal_likes_path(proposal.proposal_id),
            headers: auth_headers
 
     assert_response :success,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,10 +58,11 @@ module ActiveSupport
     def database_fixture
       Transaction.delete_all
       CommentLike.delete_all
-      Comment.delete_all
-      CommentHierarchy.delete_all
       ProposalLike.delete_all
       Proposal.delete_all
+      Comment.delete_all
+      CommentHierarchy.delete_all
+      Challenge.delete_all
       User.delete_all
       Nonce.delete_all
 


### PR DESCRIPTION
Change `:id` to `:proposal_id` in proposal routes to avoid confusion as well as update tests to check for the `liked` field.