### PR TITLE
[feature] Handle block not found error for verifying codes

### DIFF
--- a/test/models/kyc_test.rb
+++ b/test/models/kyc_test.rb
@@ -116,6 +116,16 @@ class KycTest < ActiveSupport::TestCase
 
     stub_request(:post, EthereumApi::SERVER_URL)
       .with(body: /eth_getBlockByNumber/)
+      .to_return([
+                   { body: { result: { 'number' => forward_block_number } }.to_json },
+                   { body: { result: nil }.to_json }
+                 ])
+
+    assert_equal :block_not_found, Kyc.verify_code(code),
+                 'should handle block not found number'
+
+    stub_request(:post, EthereumApi::SERVER_URL)
+      .with(body: /eth_getBlockByNumber/)
       .to_return(
         body: {
           result: {


### PR DESCRIPTION
Handle `:block_not_found` error for verifying codes just in case if the client passed an invalid code.

Decided not to use `vcr` after realizing it might add too many junk files and increase management. **We just need to be vigilant**