### PR TITLE
[feature] Improve challenge message with a prefix

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -5,6 +5,9 @@ class Challenge < ApplicationRecord
                   .configuration
                   .challenges['challenge_age']
                   .to_i
+  CHALLENGE_PREFIX = Rails
+                  .configuration
+                  .challenges['challenge_prefix']
 
   belongs_to :user
 
@@ -24,8 +27,10 @@ class Challenge < ApplicationRecord
         return [:user_not_found, nil]
       end
 
+      challenge_text = "#{CHALLENGE_PREFIX} (#{SecureRandom.hex})"
+
       challenge = Challenge.new(
-        challenge: SecureRandom.hex,
+        challenge: challenge_text,
         user: user
       )
 

--- a/config/challenges.yml
+++ b/config/challenges.yml
@@ -1,11 +1,15 @@
 development: &defaults
   challenge_age: 7 # In days
+  challenge_prefix: I am proving ownership of this address, to be used in DigixDAO Governance Platform.
 
 test:
   challenge_age: 1
+  challenge_prefix: I am proving ownership of this address, to be used in DigixDAO Governance Platform.
 
 staging:
   challenge_age: 7
+  challenge_prefix: I am proving ownership of this address, to be used in DigixDAO Governance Platform.
 
 production:
   challenge_age: 7
+  challenge_prefix: I am proving ownership of this address, to be used in DigixDAO Governance Platform.

--- a/test/factories/challenges.rb
+++ b/test/factories/challenges.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  sequence(:challenge) { |_| SecureRandom.hex }
+  sequence(:challenge) { |_| "A new challenger has appeared #{SecureRandom.hex}" }
 
   factory :user_challenge, class: 'Challenge' do
     challenge { generate(:challenge) }

--- a/test/models/challenge_test.rb
+++ b/test/models/challenge_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class ChallengeTest < ActiveSupport::TestCase
+  CHALLENGE_PREFIX = Rails.configuration.challenges['challenge_prefix']
+
   test 'create new challenge should work' do
     user = create(:user)
     params = { address: user.address }
@@ -11,6 +13,8 @@ class ChallengeTest < ActiveSupport::TestCase
 
     assert_equal :ok, ok,
                  'should work'
+    assert challenge.challenge.starts_with?(CHALLENGE_PREFIX),
+           'challenge should be prefixed'
     assert_not challenge.proven,
                'challenge should be initially unproven'
     assert_equal user.id, challenge.user_id,


### PR DESCRIPTION
Challenges are now prefixed with `I am proving ownership of this address, to be used in DigixDAO Governance Platform.`

Should not impact the frontend