### PR TITLE
[fix] Add support for multiple IPs for GraphQL ip_address context

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -10,7 +10,7 @@ class GraphqlController < ApplicationController
 
     context = {
       current_user: current_user,
-      ip_address: request.headers['X-FORWARDED-FOR']
+      ip_address: remote_ip(request.env['HTTP_X_FORWARDED_FOR'])
     }
 
     result = DaoServerSchema.execute(
@@ -28,6 +28,14 @@ class GraphqlController < ApplicationController
   end
 
   private
+
+  def remote_ip(remote_ips)
+    if remote_ips
+      remote_ips.split(',').first&.strip
+    else
+      ''
+    end
+  end
 
   def ensure_hash(ambiguous_param)
     case ambiguous_param

--- a/app/graphql/resolvers/app_user_resolver.rb
+++ b/app/graphql/resolvers/app_user_resolver.rb
@@ -21,7 +21,7 @@ module Resolvers
           else
             false
           end
-        rescue IPAddr::AddressFamilyError
+        rescue IPAddr::AddressFamilyError, IPAddr::InvalidAddressError
           false
         end
 

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GraphQLControllerTest < ActionDispatch::IntegrationTest
+  test 'ip addresses should work' do
+    post api_path,
+         params: {},
+         headers: { 'X-Forwarded-For' => '' }
+
+    assert_response :success,
+                    'should work with blank header'
+
+    post api_path,
+         params: {},
+         headers: { 'X-Forwarded-For' => '127.0.0.1' }
+
+    assert_response :success,
+                    'should work with a single ip'
+
+    post api_path,
+         params: {},
+         headers: { 'X-Forwarded-For' => '203.0.113.195, 70.41.3.18, 150.172.238.178' }
+
+    assert_response :success,
+                    'should work with multiple ips'
+
+    post api_path,
+         params: {},
+         headers: {}
+
+    assert_response :success,
+                    'should work without the header'
+  end
+end

--- a/test/graphql/app_user_query_test.rb
+++ b/test/graphql/app_user_query_test.rb
@@ -81,5 +81,14 @@ class AppUserQueryTest < ActiveSupport::TestCase
       assert unavailable_data['isUnavailable'],
              'isUnavailable should be true with unavailable countries'
     end
+
+    empty_ip_result = DaoServerSchema.execute(
+      QUERY,
+      context: { ip_address: '' },
+      variables: {}
+    )
+
+    assert_not_empty empty_ip_result['data']['appUser'],
+                     'should work even without ip address user'
   end
 end


### PR DESCRIPTION
Allow multiple addresses for `X-Forwarded-For` and only take the first one for GraphQL `ip_address`