### PR TITLE
[fix] Add reputation and quarter points to authorized user type

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -148,6 +148,16 @@ type AuthorizedUser {
   kyc: Kyc
 
   """
+  The user's accumulated points in the quarter.
+  """
+  quarterPoint: BigNumber!
+
+  """
+  The user's reputation in participating in the system.
+  """
+  reputationPoint: BigNumber!
+
+  """
   User's username
   """
   username: String
@@ -537,6 +547,16 @@ type DaoUser {
   Current KYC submission of the user
   """
   kyc: Kyc
+
+  """
+  The user's accumulated points in the quarter.
+  """
+  quarterPoint: BigNumber!
+
+  """
+  The user's reputation in participating in the system.
+  """
+  reputationPoint: BigNumber!
 
   """
   User's username

--- a/app/graphql/types/user/authorized_user_type.rb
+++ b/app/graphql/types/user/authorized_user_type.rb
@@ -23,6 +23,16 @@ module Types
               Display name of the user which should be used to identify the user.
                This is just username if it is set; otherwise, this is just `user<id>`.
             EOS
+      field :reputation_point, Types::Scalar::BigNumber,
+            null: false,
+            description: <<~EOS
+              The user's reputation in participating in the system.
+            EOS
+      field :quarter_point, Types::Scalar::BigNumber,
+            null: false,
+            description: <<~EOS
+              The user's accumulated points in the quarter.
+            EOS
       field :is_kyc_officer, Boolean,
             null: false,
             description: <<~EOS
@@ -70,6 +80,14 @@ module Types
 
       def can_comment
         !object.is_banned
+      end
+
+      def quarter_point
+        Types::Proposal::LazyPoints.new(context, object, :quarter_point)
+      end
+
+      def reputation_point
+        Types::Proposal::LazyPoints.new(context, object, :reputation_point)
       end
     end
   end


### PR DESCRIPTION
Add reputation and quarter points to authorized user type.

This is to avoid and reduce the usage of address in the UI by giving the points in the backend.