### PR TITLE
[fix] Defer loading of images for search kycs (DGDG-535)

### DIFF
--- a/app/graphql/resolvers/search_kycs_resolver.rb
+++ b/app/graphql/resolvers/search_kycs_resolver.rb
@@ -43,9 +43,6 @@ module Resolvers
                .select('*', "CONCAT(first_name, ' ', last_name) AS name")
                .order("#{sort} #{sort_by}")
                .preload(:user)
-               .with_attached_identification_proof_image
-               .with_attached_residence_proof_image
-               .with_attached_identification_pose_image
 
       query = status ? source.where(status: status) : source
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1515,14 +1515,24 @@ type Query {
     page: PositiveInteger = 1
 
     """
-    Number of records to fetch per page
+    Number of records to fetch per page. Default is 30 records per page.
     """
     pageSize: PositiveInteger = 30
 
     """
+    Sort by field for KYC. Default is `LAST_UPDATED`.
+    """
+    sort: SearchKycFieldEnum = LAST_UPDATED
+
+    """
+    Sort order of sort by for KYC. Default is `DESC`.
+    """
+    sortBy: SortByEnum = DESC
+
+    """
     Filter KYCs by their status
     """
-    status: KycStatusEnum
+    status: KycStatusEnum = null
   ): KycPaginatedConnection!
 
   """
@@ -1672,6 +1682,41 @@ enum ResidenceProofTypeEnum {
   Utility bill such as electricity or water
   """
   UTILITY_BILL
+}
+
+"""
+Fields to be sorted on for `searchKycs` query`
+"""
+enum SearchKycFieldEnum {
+  """
+  Client's country of residence
+  """
+  COUNTRY_OF_RESIDENCE
+
+  """
+  KYC update timestamp
+  """
+  LAST_UPDATED
+
+  """
+  Client's full name
+  """
+  NAME
+
+  """
+  Client's country of residence
+  """
+  NATIONALITY
+
+  """
+  KYC status
+  """
+  STATUS
+
+  """
+  Client's user ID
+  """
+  USER_ID
 }
 
 enum SortByEnum {

--- a/app/graphql/types/kyc/identification_pose_type.rb
+++ b/app/graphql/types/kyc/identification_pose_type.rb
@@ -16,6 +16,23 @@ module Types
               since file storage is asynchronous, so be careful with the mutation.
               Howver, it should be a valid object in practice.
             EOS
+
+      def image
+        encode_attachment(object[:image].attachment)
       end
+
+      private
+
+      def encode_attachment(attachment)
+        return nil unless attachment && (blob = attachment.blob)
+
+        {
+          filename: blob.filename,
+          file_size: blob.byte_size,
+          content_type: blob.content_type,
+          data_url: "data:#{blob.content_type};base64,#{Base64.strict_encode64(blob.download)}"
+        }
+      end
+    end
   end
 end

--- a/app/graphql/types/kyc/identification_proof_type.rb
+++ b/app/graphql/types/kyc/identification_proof_type.rb
@@ -22,6 +22,23 @@ module Types
               since file storage is asynchronous, so be careful with the mutation.
               Howver, it should be a valid object in practice.
             EOS
+
+      def image
+        encode_attachment(object[:image].attachment)
       end
+
+      private
+
+      def encode_attachment(attachment)
+        return nil unless attachment && (blob = attachment.blob)
+
+        {
+          filename: blob.filename,
+          file_size: blob.byte_size,
+          content_type: blob.content_type,
+          data_url: "data:#{blob.content_type};base64,#{Base64.strict_encode64(blob.download)}"
+        }
+      end
+    end
   end
 end

--- a/app/graphql/types/kyc/kyc_type.rb
+++ b/app/graphql/types/kyc/kyc_type.rb
@@ -127,7 +127,7 @@ module Types
           number: object['identification_proof_number'],
           type: object['identification_proof_type'],
           expiration_date: object['identification_proof_expiration_date'],
-          image: encode_attachment(object.identification_proof_image.attachment)
+          image: object.identification_proof_image
         }
       end
 
@@ -142,14 +142,14 @@ module Types
             postal_code: object['postal_code']
           },
           type: object['residence_proof_type'],
-          image: encode_attachment(object.residence_proof_image.attachment)
+          image: object.residence_proof_image
         }
       end
 
       def identification_pose
         {
           verification_code: object['verification_code'],
-          image: encode_attachment(object.identification_pose_image.attachment)
+          image: object.identification_pose_image
         }
       end
 

--- a/app/graphql/types/kyc/residence_proof_type.rb
+++ b/app/graphql/types/kyc/residence_proof_type.rb
@@ -19,6 +19,23 @@ module Types
               since file storage is asynchronous, so be careful with the mutation.
               Howver, it should be a valid object in practice.
             EOS
+
+      def image
+        encode_attachment(object[:image].attachment)
       end
+
+      private
+
+      def encode_attachment(attachment)
+        return nil unless attachment && (blob = attachment.blob)
+
+        {
+          filename: blob.filename,
+          file_size: blob.byte_size,
+          content_type: blob.content_type,
+          data_url: "data:#{blob.content_type};base64,#{Base64.strict_encode64(blob.download)}"
+        }
+      end
+    end
   end
 end

--- a/test/graphql/kyc_query_test.rb
+++ b/test/graphql/kyc_query_test.rb
@@ -7,6 +7,21 @@ class KycQueryTest < ActiveSupport::TestCase
     query($id: String!) {
       kyc(id: $id) {
         id
+        identificationProof {
+          image {
+            dataUrl
+            }
+          }
+        residenceProof {
+          image {
+            dataUrl
+          }
+        }
+        identificationPose {
+          image {
+            dataUrl
+          }
+        }
       }
     }
   EOS

--- a/test/graphql/search_kycs_query_test.rb
+++ b/test/graphql/search_kycs_query_test.rb
@@ -107,6 +107,7 @@ class SearchKycsQueryTest < ActiveSupport::TestCase
 
     Kyc.statuses.keys.each do |status|
       create_list(:kyc, 10, status: status.to_sym)
+      Kyc.connection.execute('UPDATE `kycs` SET `updated_at` = FROM_DAYS(id), `created_at` = FROM_DAYS(id)')
     end
 
     status = generate(:kyc_status)


### PR DESCRIPTION
Defer loading of images for search kycs.

In particular, it is discouraged to search add `image` fields for `searchKycs` query and just transfer it to `kyc` query instead.